### PR TITLE
Fixed check columns function

### DIFF
--- a/lib/core/dataAccess.js
+++ b/lib/core/dataAccess.js
@@ -126,7 +126,7 @@ class DataAccess {
   async CheckTableColumnExist(tableName, columnName) {
     try {
       const sql = `SELECT column_name FROM information_schema.columns WHERE table_name = '${tableName}' AND column_name = '${columnName}' LIMIT 1`
-      const res = await this.Transaction({ params: [sql] }) // v0.1.9 bug fixes
+      const res = await this.Transaction({ params: [{sql}] }) // v0.1.9 bug fixes
       if (res[0].rows.length > 0) return true
       return false
     } catch (e) {


### PR DESCRIPTION
Check columns was failing because sql was passed as a bare string and not inside of an object