### PR TITLE
moved catch to after client initialization, return array with empty r…

### DIFF
--- a/lib/core/dataAccess.js
+++ b/lib/core/dataAccess.js
@@ -139,17 +139,19 @@ class DataAccess {
         '"params" is invalid: Expected "Array" but got "null" or "undefined"'
       )
 
-    // v0.1.9 for some real world situations we shouldn't throw error here -- Janden
-    if (params.length === 0) {
-      console.warn('[Warning]: "params" is an empty array, skipped')
-      return transaction ? transaction([]) : []
-    }
-
     const client = args.client || (await this.conn.connect())
     const result = returnWithAlias ? {} : []
     this.clientCounter[client.processID]
       ? (this.clientCounter[client.processID] += 1)
       : (this.clientCounter[client.processID] = 1)
+
+    // v0.1.9 for some real world situations we shouldn't throw error here -- Janden
+    if (params.length === 0) {
+      console.warn('[Warning]: "params" is an empty array, skipped')
+      return transaction
+        ? transaction([returnSingleRecord ? {} : [], client])
+        : []
+    }
 
     try {
       await client.query('BEGIN')


### PR DESCRIPTION
Error:

When calling `multiInsert` with an empty array of objects, the empty params array was causing `Transaction` to return early with an empty array. This would crash callback functions by failing to provide the expected data format

Solution:

When params is empty, return an array with an empty result and the initialized client